### PR TITLE
Remove deprecated _flat warning

### DIFF
--- a/src/edit/handler/Edit.Poly.js
+++ b/src/edit/handler/Edit.Poly.js
@@ -22,10 +22,10 @@ L.Edit.Poly = L.Handler.extend({
 	// Compatibility method to normalize Poly* objects
 	// between 0.7.x and 1.0+
 	_defaultShape: function () {
-		if (!L.Polyline._flat) {
+		if (!L.LineUtil.isFlat) {
 			return this._poly._latlngs;
 		}
-		return L.Polyline._flat(this._poly._latlngs) ? this._poly._latlngs : this._poly._latlngs[0];
+		return L.LineUtil.isFlat(this._poly._latlngs) ? this._poly._latlngs : this._poly._latlngs[0];
 	},
 
 	_eachVertexHandler: function (callback) {
@@ -117,10 +117,10 @@ L.Edit.PolyVerticesEdit = L.Handler.extend({
 	// Compatibility method to normalize Poly* objects
 	// between 0.7.x and 1.0+
 	_defaultShape: function () {
-		if (!L.Polyline._flat) {
+		if (!L.LineUtil.isFlat) {
 			return this._latlngs;
 		}
-		return L.Polyline._flat(this._latlngs) ? this._latlngs : this._latlngs[0];
+		return L.LineUtil.isFlat(this._latlngs) ? this._latlngs : this._latlngs[0];
 	},
 
 	// @method addHooks(): void


### PR DESCRIPTION
Follow-up PR after #2.

---

When using `leaflet-draw` package, console warnings would appear with `Deprecated use of _flat, please use L.LineUtil.isFlat instead.`
